### PR TITLE
Migrate to mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ version = '1.1.1'
 sourceCompatibility = 1.8
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         url 'https://build.shibboleth.net/nexus/content/repositories/releases/'
     }


### PR DESCRIPTION
Supports deprecation of bintray and jcenter.

See https://github.com/ausaccessfed/stockpile/issues/72

FWIW:

```
$ ./gradlew build
:compileJava
Download https://build.shibboleth.net/nexus/content/repositories/releases/net/shibboleth/idp/idp-attribute-api/3.3.1/idp-attribute-api-3.3.1.pom
Download https://build.shibboleth.net/nexus/content/repositories/releases/net/shibboleth/idp/idp-parent/3.3.1/idp-parent-3.3.1.pom
Download https://repo1.maven.org/maven2/net/shibboleth/parent-v3/10/parent-v3-10.pom
Download https://build.shibboleth.net/nexus/content/repositories/releases/net/shibboleth/idp/idp-attribute-resolver-api/3.3.1/idp-attribute-resolver-api-3.3.1.pom
Download https://build.shibboleth.net/nexus/content/repositories/releases/net/shibboleth/idp/idp-attribute-resolver-impl/3.3.1/idp-attribute-resolver-impl-3.3.1.pom
Download https://build.shibboleth.net/nexus/content/repositories/releases/net/shibboleth/idp/idp-attribute-resolver-spring/3.3.1/idp-attribute-resolver-spring-3.3.1.pom
Download https://repo1.maven.org/maven2/org/springframework/spring-jdbc/4.3.2.RELEASE/spring-jdbc-4.3.2.RELEASE.pom
Download https://repo1.maven.org/maven2/org/opensaml/opensaml-core/3.3.0/opensaml-core-3.3.0.pom
...
:pmdTest
:check
:build

BUILD SUCCESSFUL

Total time: 3 mins 25.587 secs
```